### PR TITLE
Define RDF-Connect Processors Ontology

### DIFF
--- a/rdf-connect-processors.ttl
+++ b/rdf-connect-processors.ttl
@@ -1,0 +1,44 @@
+@prefix vann: <http://purl.org/vocab/vann/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix prov: <http://www.w3.org/ns/prov#>.
+@prefix cc: <http://creativecommons.org/ns#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix rdfc: <https://w3id.org/rdf-connect#>.
+@prefix rdfcp: <https://w3id.org/rdf-connect/processors#>.
+
+#################################################################
+# Ontology metadata
+#################################################################
+rdfcp: a owl:Ontology;
+  cc:license <https://creativecommons.org/licenses/by/4.0/>;
+  dct:author <https://smessaert.be/#me>;
+  dct:contributor [
+      a foaf:Person;
+      foaf:name "Arthur Vercruysse";
+    ],
+    <https://julianrojas.org/#me>;
+  dct:issued "2026-06-23"^^xsd:date;
+  dct:modified "2026-06-23"^^xsd:date;
+  vann:preferredNamespacePrefix "rdfcp";
+  vann:preferredNamespaceUri "https://w3id.org/rdf-connect/processors#";
+  rdfs:label "RDF-Connect Processors Ontology"@en;
+  rdfs:comment "An ontology for describing processor definitions and their commonly used properties in RDF-Connect. Functions as a placeholder namespace for processor definitions."@en;
+  owl:versionInfo "0.3.0".
+
+
+rdfcp:input a owl:ObjectProperty;
+  rdfs:label "input"@en;
+  rdfs:comment "Relates a processor to its input data channel(s), typically a Reader."@en;
+  rdfs:domain rdfc:Processor;
+  rdfs:range rdfc:Reader;
+  rdfs:subPropertyOf prov:used.
+
+rdfcp:output a owl:ObjectProperty;
+  rdfs:label "output"@en;
+  rdfs:comment "Relates a processor to its output data channel(s), typically a Writer."@en;
+  rdfs:domain rdfc:Processor;
+  rdfs:range rdfc:Writer;
+  rdfs:subPropertyOf prov:generated.

--- a/rdf-connect.ttl
+++ b/rdf-connect.ttl
@@ -1,3 +1,4 @@
+@prefix vann: <http://purl.org/vocab/vann/>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
@@ -10,7 +11,7 @@
 #################################################################
 # Ontology metadata
 #################################################################
-<https://w3id.org/rdf-connect/ontology> a owl:Ontology;
+rdfc: a owl:Ontology;
   cc:license <https://creativecommons.org/licenses/by/4.0/>;
   dct:author [
     a foaf:Person;
@@ -25,6 +26,8 @@
     <https://smessaert.be/#me>;
   dct:issued "2024-07-29"^^xsd:date;
   dct:modified "2026-06-15"^^xsd:date;
+  vann:preferredNamespacePrefix "rdfc";
+  vann:preferredNamespaceUri "https://w3id.org/rdf-connect#";
   rdfs:label "RDF-Connect Ontology"@en;
   rdfs:comment "An ontology for describing programming language-specific runners, processors and pipelines in RDF-based data processing frameworks."@en;
   owl:versionInfo "0.3.0".


### PR DESCRIPTION
This pull request introduces improvements to the ontology metadata for the RDF-Connect project and adds a new ontology file for processor definitions. The main changes focus on standardizing metadata, enhancing namespace declaration, and introducing a dedicated ontology for processors.

**Ontology metadata and namespace improvements:**

* Standardized the ontology metadata in `rdf-connect.ttl` by switching the ontology IRI to use the `rdfc:` prefix, and added `vann:preferredNamespacePrefix` and `vann:preferredNamespaceUri` properties for better namespace documentation. [[1]](diffhunk://#diff-fef0058838d40875913dacb9e66b7b6c156a6f2488096f3b2dba3916a27ad936L13-R14) [[2]](diffhunk://#diff-fef0058838d40875913dacb9e66b7b6c156a6f2488096f3b2dba3916a27ad936R29-R30) [[3]](diffhunk://#diff-fef0058838d40875913dacb9e66b7b6c156a6f2488096f3b2dba3916a27ad936R1) [[4]](diffhunk://#diff-fef0058838d40875913dacb9e66b7b6c156a6f2488096f3b2dba3916a27ad936R1)

**New processors ontology:**

* Added a new file, `rdf-connect-processors.ttl`, defining the RDF-Connect Processors Ontology, including metadata, authorship, and two new object properties: `rdfcp:input` and `rdfcp:output`, which relate processors to their input and output channels, respectively.
* `processors` instead of `properties` was used as this namespace will also be used for processor identifiers, and not solely their properties. Properties also reside on the processor though.